### PR TITLE
[FIX] - unionByName no data_transformation e limpeza de testes

### DIFF
--- a/src/cidacsrl/adapters/outbound/spark/data_transformation_adapter.py
+++ b/src/cidacsrl/adapters/outbound/spark/data_transformation_adapter.py
@@ -42,4 +42,4 @@ class SparkDataTransformationAdapter(DataTransformationPort):
         valid_dfs = [df for df in phase_outputs if df is not None]
         if not valid_dfs:
             raise ValueError("Nenhum DataFrame válido foi fornecido para consolidação de resultados.")
-        return functools.reduce(lambda df1, df2: df1.unionAll(df2), valid_dfs)
+        return functools.reduce(lambda df1, df2: df1.unionByName(df2, allowMissingColumns=True), valid_dfs)

--- a/tests/fixtures/configs/env/linkage_acidentes_obitos_multisearch_env.yml
+++ b/tests/fixtures/configs/env/linkage_acidentes_obitos_multisearch_env.yml
@@ -13,11 +13,8 @@ storage:
 
 execution:
   audit_log_path: "tests/data/audit_logs"
-  sample_fraction: 0.5
-  sample_seed: 7
   partitioning:
     partition_column: "uf_acidente"
-    filter_partitions: ["SP", "MG", "BA", "RJ"]
 
 specification:
   indexing_path: "tests/fixtures/configs/specs/obitos_example_index.yml"


### PR DESCRIPTION
Ajusta o `union` do `data_transformation` para usar `unionByName`, lidando melhor com colunas ausentes entre fases, e remove `seed`/`sample_fraction` dos testes.

Parte do conjunto da **v4.0.0-beta.2**.
