### PR TITLE
[CHORE] - Dockerfile HPC offline e alinhamento de versões dos jars

### DIFF
--- a/deploy/hpc/Dockerfile
+++ b/deploy/hpc/Dockerfile
@@ -1,0 +1,90 @@
+# syntax=docker/dockerfile:1
+#
+# Imagem de execução OFFLINE (air-gapped) para HPC — pensada para ser
+# convertida em Singularity/Apptainer (.sif) e rodar em nós sem internet.
+#
+# Diferença para tests/environment/Dockerfile (ambiente de laboratório local):
+# aqui NÃO existe nenhuma etapa que resolva jars em runtime. Todos os jars da
+# JVM são baixados no build (máquina COM internet) e embutidos em
+# /opt/spark/jars, de onde o Spark os carrega automaticamente. Assim o
+# artefato final não depende de `spark.jars.packages` (resolução Ivy/Maven).
+#
+# Build (numa máquina com internet, a partir da raiz do repositório):
+#   docker build -f deploy/hpc/Dockerfile --target full -t cidacsrl:offline .
+#
+# Alvos disponíveis:
+#   linkage        -> linkage / indexing  (jar do conector Elasticsearch)
+#   deduplication  -> deduplication       (jar do GraphFrames)
+#   full           -> todas as etapas num único artefato (recomendado p/ HPC)
+
+ARG SPARK_IMAGE=apache/spark:3.5.8-python3
+ARG ES_CONNECTOR_VERSION=9.1.8
+ARG GRAPHFRAMES_VERSION=0.8.3-spark3.5-s_2.12
+
+# ---------------------------------------------------------------------------
+# Stage 1: baixa os jars da JVM (única etapa que precisa de internet)
+# ---------------------------------------------------------------------------
+FROM curlimages/curl:8.11.0 AS jar-downloader
+ARG ES_CONNECTOR_VERSION
+ARG GRAPHFRAMES_VERSION
+WORKDIR /jars
+
+RUN curl -fL "https://repo1.maven.org/maven2/org/elasticsearch/elasticsearch-spark-30_2.12/${ES_CONNECTOR_VERSION}/elasticsearch-spark-30_2.12-${ES_CONNECTOR_VERSION}.jar" \
+        -o "elasticsearch-spark-30_2.12-${ES_CONNECTOR_VERSION}.jar" && \
+    curl -fL "https://repos.spark-packages.org/graphframes/graphframes/${GRAPHFRAMES_VERSION}/graphframes-${GRAPHFRAMES_VERSION}.jar" \
+        -o "graphframes-${GRAPHFRAMES_VERSION}.jar"
+
+# ---------------------------------------------------------------------------
+# Stage 2: build do wheel do cidacsrl
+# ---------------------------------------------------------------------------
+FROM python:3.12-slim AS python-builder
+WORKDIR /build
+RUN pip install --no-cache-dir build
+COPY pyproject.toml README.md ./
+COPY src/cidacsrl ./src/cidacsrl
+RUN python -m build --wheel
+
+# ---------------------------------------------------------------------------
+# Stage 3: runtime base (Spark + cidacsrl instalado, ainda SEM jars)
+# ---------------------------------------------------------------------------
+FROM ${SPARK_IMAGE} AS runtime
+USER root
+WORKDIR /app
+
+ENV PYTHONUNBUFFERED=1
+# pyspark usa o Spark embutido em SPARK_HOME; qualquer jar em /opt/spark/jars
+# é adicionado ao classpath automaticamente, sem spark.jars.packages.
+ENV SPARK_HOME=/opt/spark
+
+COPY --from=python-builder /build/dist/*.whl /tmp/wheels/
+RUN pip install --no-cache-dir /tmp/wheels/*.whl graphframes && \
+    rm -rf /tmp/wheels
+
+USER spark
+
+# ---------------------------------------------------------------------------
+# Alvo: linkage / indexing (conector Elasticsearch)
+# ---------------------------------------------------------------------------
+FROM runtime AS linkage
+ARG ES_CONNECTOR_VERSION
+USER root
+COPY --from=jar-downloader /jars/elasticsearch-spark-30_2.12-${ES_CONNECTOR_VERSION}.jar /opt/spark/jars/
+USER spark
+
+# ---------------------------------------------------------------------------
+# Alvo: deduplication (GraphFrames)
+# ---------------------------------------------------------------------------
+FROM runtime AS deduplication
+ARG GRAPHFRAMES_VERSION
+USER root
+COPY --from=jar-downloader /jars/graphframes-${GRAPHFRAMES_VERSION}.jar /opt/spark/jars/
+USER spark
+
+# ---------------------------------------------------------------------------
+# Alvo: full — um único artefato serve para linkage, indexing e deduplication.
+# É o alvo recomendado para HPC: gera um único .sif para todo o pipeline.
+# ---------------------------------------------------------------------------
+FROM runtime AS full
+USER root
+COPY --from=jar-downloader /jars/*.jar /opt/spark/jars/
+USER spark

--- a/tests/environment/Dockerfile
+++ b/tests/environment/Dockerfile
@@ -19,8 +19,8 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends curl && \
     rm -rf /var/lib/apt/lists/*
 
-RUN curl -fL "https://repo1.maven.org/maven2/org/elasticsearch/elasticsearch-spark-30_2.12/9.2.8/elasticsearch-spark-30_2.12-9.2.8.jar" \
-    -o /elasticsearch-spark-30_2.12-9.2.8.jar
+RUN curl -fL "https://repo1.maven.org/maven2/org/elasticsearch/elasticsearch-spark-30_2.12/9.1.8/elasticsearch-spark-30_2.12-9.1.8.jar" \
+    -o /elasticsearch-spark-30_2.12-9.1.8.jar
 
 
 # Download do JAR do GraphFrames
@@ -30,8 +30,8 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends curl && \
     rm -rf /var/lib/apt/lists/*
 
-RUN curl -fL "https://repos.spark-packages.org/graphframes/graphframes/0.8.2-spark3.2-s_2.12/graphframes-0.8.2-spark3.2-s_2.12.jar" \
-    -o /graphframes-0.8.2.jar
+RUN curl -fL "https://repos.spark-packages.org/graphframes/graphframes/0.8.3-spark3.5-s_2.12/graphframes-0.8.3-spark3.5-s_2.12.jar" \
+    -o /graphframes-0.8.3.jar
 
 
 # Runtime Spark
@@ -57,7 +57,7 @@ USER spark
 FROM runtime-spark AS runtime-spark-graphframes
 
 USER root
-COPY --from=graphframes-jar-downloader /graphframes-0.8.2.jar /opt/spark/jars/
+COPY --from=graphframes-jar-downloader /graphframes-0.8.3.jar /opt/spark/jars/
 RUN pip install --no-cache-dir graphframes
 USER spark
 
@@ -65,7 +65,7 @@ USER spark
 FROM runtime-spark AS runtime-spark-es
 
 USER root
-COPY --from=es-jar-downloader /elasticsearch-spark-30_2.12-9.2.8.jar /opt/spark/jars/
+COPY --from=es-jar-downloader /elasticsearch-spark-30_2.12-9.1.8.jar /opt/spark/jars/
 USER spark
 
 
@@ -120,7 +120,7 @@ RUN pip install --no-cache-dir \
 
 COPY src/cidacsrl/ ./src/cidacsrl/
 COPY pyproject.toml ./
-COPY --from=es-jar-downloader /elasticsearch-spark-30_2.12-9.2.8.jar /opt/spark/jars/
+COPY --from=es-jar-downloader /elasticsearch-spark-30_2.12-9.1.8.jar /opt/spark/jars/
 
 EXPOSE 8888
 

--- a/tests/fixtures/configs/specs/linkage_acidentes_obitos.yml
+++ b/tests/fixtures/configs/specs/linkage_acidentes_obitos.yml
@@ -30,7 +30,7 @@ blocking_phases:
   - phase_name: "fase_exata"
     phase_description: "Match determinístico por nome completo e nome da mãe (must)."
     enabled: true
-    candidate_limit: 100
+    candidate_limit: 10
     strong_match_score_threshold: 0.99
     rules:
       - source_column: "nome_completo"
@@ -54,7 +54,7 @@ blocking_phases:
   - phase_name: "fase_fuzzy"
     phase_description: "Match probabilístico com Jaro-Winkler e reforço geográfico."
     enabled: true
-    candidate_limit: 100
+    candidate_limit: 25
     strong_match_score_threshold: 0.75
     # Filtro específico da fase (combinado com o do workflow via merge aditivo):
     # restringe candidatos à mesma UF por comparação dinâmica de coluna.


### PR DESCRIPTION
Adiciona a imagem `deploy/hpc/Dockerfile` (air-gapped, jars embutidos para Singularity/Apptainer) referenciada no guia de execução em cluster, alinha as versões dos jars do ambiente de testes às canônicas (ES 9.1.8, GraphFrames 0.8.3-spark3.5) e reduz `candidate_limit` no fixture e2e.

Parte do conjunto da **v4.0.0-beta.2**.
