### PR TITLE
chore(deploy): alinha Python 3.12 e pyspark 3.5.8 no Dockerfile

### DIFF
--- a/deploy/hpc/Dockerfile
+++ b/deploy/hpc/Dockerfile
@@ -17,7 +17,8 @@
 #   deduplication  -> deduplication       (jar do GraphFrames)
 #   full           -> todas as etapas num único artefato (recomendado p/ HPC)
 
-ARG SPARK_IMAGE=apache/spark:3.5.8-python3
+
+ARG SPARK_IMAGE=apache/spark:3.5.8-scala2.12-java17-ubuntu
 ARG ES_CONNECTOR_VERSION=9.1.8
 ARG GRAPHFRAMES_VERSION=0.8.3-spark3.5-s_2.12
 
@@ -51,6 +52,23 @@ FROM ${SPARK_IMAGE} AS runtime
 USER root
 WORKDIR /app
 
+# Instala Python 3.12 (deadsnakes) — precisa de internet, só nesta etapa de
+# build. O artefato final (.sif) não depende mais de rede.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends software-properties-common gnupg curl ca-certificates && \
+    add-apt-repository -y ppa:deadsnakes/ppa && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends python3.12 python3.12-venv && \
+    curl -sS https://bootstrap.pypa.io/get-pip.py | python3.12 && \
+    ln -sf /usr/bin/python3.12 /usr/local/bin/python3 && \
+    ln -sf /usr/bin/python3.12 /usr/local/bin/python && \
+    apt-get purge -y software-properties-common gnupg && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV PYSPARK_PYTHON=/usr/bin/python3.12
+ENV PYSPARK_DRIVER_PYTHON=/usr/bin/python3.12
+ENV PATH=/usr/local/bin:$PATH
 ENV PYTHONUNBUFFERED=1
 # pyspark usa o Spark embutido em SPARK_HOME; qualquer jar em /opt/spark/jars
 # é adicionado ao classpath automaticamente, sem spark.jars.packages.

--- a/poetry.lock
+++ b/poetry.lock
@@ -3096,4 +3096,4 @@ dev = ["pytest", "setuptools"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12"
-content-hash = "3f29172d462970a7db04610e30d46b19bdc408176cd1451f2c8b2454155668c6"
+content-hash = "4e63cb34d9a9977e34c4c9cf110b9a12dad06ff4c32c0ff9e8dc1f7f3da7fcce"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "pyyaml>=6.0.2",
     "jellyfish>=1.1.03",
     "pandas>=1.3.0",
-    "pyspark>=3.4.0",
+    "pyspark~=3.5.8",
     "graphframes"
 ]
 

--- a/tests/e2e/linkage/run_e2e_pipeline.py
+++ b/tests/e2e/linkage/run_e2e_pipeline.py
@@ -90,7 +90,8 @@ def verify_and_validate_e2e_results(
 
     source_table = linkage_spec["source_table"]
     target_es_index = linkage_spec["target_es_index"]
-    project_output_path = base_output_path / f"linkage_{source_table}_{target_es_index}"
+    linkage_project_name = linkage_spec.get("workflow_name") or f"linkage_{source_table}_{target_es_index}"
+    project_output_path = base_output_path / linkage_project_name
 
     logger.info(f"Varrendo os resultados consolidados na árvore do projeto: {project_output_path}")
     if not project_output_path.exists():

--- a/tests/environment/Dockerfile
+++ b/tests/environment/Dockerfile
@@ -35,13 +35,27 @@ RUN curl -fL "https://repos.spark-packages.org/graphframes/graphframes/0.8.3-spa
 
 
 # Runtime Spark
-FROM apache/spark:3.5.8-python3 AS runtime-spark
+FROM apache/spark:3.5.8-scala2.12-java17-ubuntu AS runtime-spark
 
 USER root
 WORKDIR /app
 
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends software-properties-common gnupg curl ca-certificates && \
+    add-apt-repository -y ppa:deadsnakes/ppa && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends python3.12 python3.12-venv && \
+    curl -sS https://bootstrap.pypa.io/get-pip.py | python3.12 && \
+    ln -sf /usr/bin/python3.12 /usr/local/bin/python3 && \
+    ln -sf /usr/bin/python3.12 /usr/local/bin/python && \
+    apt-get purge -y software-properties-common gnupg && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV PYSPARK_PYTHON=/usr/bin/python3.12
+ENV PYSPARK_DRIVER_PYTHON=/usr/bin/python3.12
 ENV PYTHONPATH=/app:$PYTHONPATH
-ENV PATH=/opt/spark/bin:$PATH
+ENV PATH=/usr/local/bin:/opt/spark/bin:$PATH
 
 COPY --from=builder /build/spark_packages /opt/spark/pyfiles
 RUN pip install --no-cache-dir /opt/spark/pyfiles/*.whl

--- a/tests/environment/Dockerfile
+++ b/tests/environment/Dockerfile
@@ -1,5 +1,5 @@
 # Build do pacote Python
-FROM python:3.10-slim AS builder
+FROM python:3.12-slim AS builder
 
 WORKDIR /build
 RUN pip install --no-cache-dir build
@@ -98,7 +98,7 @@ CMD ["tail", "-f", "/dev/null"]
 
 
 # Jupyter
-FROM python:3.10-slim AS jupyter-dev
+FROM python:3.12-slim AS jupyter-dev
 
 WORKDIR /app
 

--- a/tests/fixtures/configs/env/deduplicate_acidentes_obitos_env.yml
+++ b/tests/fixtures/configs/env/deduplicate_acidentes_obitos_env.yml
@@ -1,7 +1,7 @@
 app_name: "CIDACS-RL Deduplicação — Acidentes × Óbitos (E2E)"
 
 storage:
-  source_path: "tests/data/output/linkage_acidentes_example_obitos_example_index/phase_match=fase_exata"
+  source_path: "tests/data/output/acidentes_obitos/phase_match=fase_exata"
   source_format: "parquet"
   output_path: "tests/output/dedup_acidentes_obitos"
   output_format: "parquet"


### PR DESCRIPTION
## Summary
- Estágios `builder` e `jupyter-dev` do `tests/environment/Dockerfile` usavam `python:3.10-slim`, incompatível com `requires-python = ">=3.12"` do `pyproject.toml` — o build do wheel `cidacsrl` falhava. Ambos agora usam `python:3.12-slim`.
- `pyspark` estava sem teto de versão (`>=3.4.0`) em `pyproject.toml`, enquanto o resto do projeto usa `3.5.8`. Sem o teto, `pip download .` resolvia `pyspark 4.1.2`, divergindo do runtime real. Travado para `~=3.5.8`.
- `tests/e2e/linkage/run_e2e_pipeline.py`: a validação pós-execução ignorava o campo `workflow_name` (`LinkageSpecification.linkage_project_name`), procurando a pasta de output errada. Corrigido para replicar a mesma lógica do domínio.
- `tests/fixtures/configs/env/deduplicate_acidentes_obitos_env.yml`: `source_path` apontava para o diretório de output antigo, quebrando o E2E de deduplicação pelo mesmo motivo. Atualizado.
- Build completo de `runtime-spark-es`/`runtime-spark-graphframes` (`tests/environment/Dockerfile`) e `deploy/hpc/Dockerfile`: nenhuma imagem oficial do Spark (testado 3.5.8, 4.0.2, 4.1.2, 4.2.0-preview5) embute Python 3.12 — todas usam 3.10.12 fixo. PySpark 3.5.8 suporta 3.12 normalmente, então a imagem base virou a variante sem Python embutido (`apache/spark:3.5.8-scala2.12-java17-ubuntu`) com 3.12 instalado via deadsnakes, mantendo `requires-python>=3.12` uniforme sem shims no código.

## Test plan
- [x] `docker build --target builder` resolve `pyspark 3.5.8` (antes resolvia `4.1.2`)
- [x] `poetry lock` regenerado, continua em `pyspark 3.5.8`
- [x] `make run-e2e-pipeline ENV=linkage_acidentes_obitos_env.yml` — SUCESSO (27 blocos, 3273 pares)
- [x] `make run-e2e-dedup` — SUCESSO (1772 pares, 1521 clusters)
- [x] `docker build --target runtime-spark-es` / `--target runtime-spark-graphframes` — build completo, Python 3.12.13, cidacsrl importável, GraphFrames executando via py4j
- [x] `docker build -f deploy/hpc/Dockerfile --target full` — build completo, Python 3.12.13, ambos os jars presentes